### PR TITLE
Add comments and a corresponding TODO on the usage of the 'label'

### DIFF
--- a/example/network_params_microcircuit.yaml
+++ b/example/network_params_microcircuit.yaml
@@ -1,4 +1,7 @@
 ---
+# Label, that is used to trigger calculation of network-specific derived
+# parameters. Changing this label currently disables the calculation of
+# microcircuit specific derived parameters!
 label: microcircuit
 
 populations:

--- a/lif_meanfield_tools/network.py
+++ b/lif_meanfield_tools/network.py
@@ -180,6 +180,11 @@ class Network(object):
         D = np.transpose(D)
         derived_params['Delay_sd'] = D
 
+        # TODO: Put calculation of network-specifc dervied parameters
+        # into an external script for enhanced generalization.
+        # (e.g. trigger execution of external script called <label>.py here)
+        # Changing the label currently leads to difference which are hard to
+        # track down.
         if self.network_params['label'] == 'microcircuit':
             # larger weight for L4E->L23E connections
             derived_params['W'][0][2] *= 2.0


### PR DESCRIPTION
The .yaml with the network parameters currently has a parameter called 'label'. If this label is set to 'microcircuit', while initializing the network it triggers the calculation of microcircuit-specific derived parameters. 

Currently there is no documentation of how changing this label influences the calculations and can thus lead to differences which are hard to debug.