### PR TITLE
Simplify comparison

### DIFF
--- a/lif_meanfield_tools/aux_calcs.py
+++ b/lif_meanfield_tools/aux_calcs.py
@@ -106,7 +106,7 @@ def nu_0(tau_m, tau_r, V_th_rel, V_0_rel, mu, sigma):
     float:
         Stationary firing rate in Hz.
     """
-    if mu <= V_th_rel + (0.95 * abs(V_th_rel) - abs(V_th_rel)):
+    if mu <= V_th_rel - 0.05 * abs(V_th_rel):
         return siegert1(tau_m, tau_r, V_th_rel, V_0_rel, mu, sigma)
     else:
         return siegert2(tau_m, tau_r, V_th_rel, V_0_rel, mu, sigma)


### PR DESCRIPTION
Going through the multi area model source code we realized there was a condition in `nu_0()` which could be simplified. Comparing with the lif_meanfield_tools we realized it was exactly the same here and could also be improved.